### PR TITLE
Update ServiceNowRequest.cs

### DIFF
--- a/ServiceNowNewsAndNotificationsAPI/ServiceNowRequest.cs
+++ b/ServiceNowNewsAndNotificationsAPI/ServiceNowRequest.cs
@@ -35,8 +35,8 @@ namespace ServiceNowNewsAndNotificationsAPI
             request.Method = WebRequestMethods.Http.Get;
             request.Accept = "application/json";
 
-            string userName = "readonlyservice";
-            string password = "ServiceNow";
+            string userName = "";
+            string password = "";
             string encoded = System.Convert.ToBase64String(System.Text.Encoding.GetEncoding("ISO-8859-1").GetBytes(userName + ":" + password));
             request.Headers.Add("Authorization", "Basic " + encoded);
 


### PR DESCRIPTION
Removal of the username and password values on line 38, 39 and setting them to an empty string value. Huu Ly has confirmed that this API code is no longer in use, but would like to keep the code in Github for historical purposes. This should no longer violate any Github security concerns.